### PR TITLE
ci: claude-code-action の prompt → direct_prompt に修正し id-token 権限を追加

### DIFF
--- a/.github/workflows/monthly-data-update.yml
+++ b/.github/workflows/monthly-data-update.yml
@@ -15,6 +15,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4
@@ -37,7 +38,7 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          prompt: /download-data ${{ steps.date.outputs.yearmonth }}
+          direct_prompt: /download-data ${{ steps.date.outputs.yearmonth }}
 
       - name: 変更をコミット＆プッシュ
         run: |


### PR DESCRIPTION
## Summary

- `prompt` は `anthropics/claude-code-action@beta` の無効なパラメータだったため `direct_prompt` に修正
- OIDC トークン取得のために `id-token: write` パーミッションを追加

## 原因

https://github.com/kazrin/sk/actions/runs/26735134103/job/78786737616 のジョブが以下のエラーで失敗していた:

1. `Unexpected input(s) 'prompt'` — パラメータ名が変わっていた
2. `Could not fetch an OIDC token` — `id-token: write` が permissions に不足していた

🤖 Generated with [Claude Code](https://claude.com/claude-code)