### PR TITLE
ci: claude-code-action のパラメータとモードを修正

### DIFF
--- a/.github/workflows/monthly-data-update.yml
+++ b/.github/workflows/monthly-data-update.yml
@@ -38,6 +38,7 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          mode: agent
           direct_prompt: /download-data ${{ steps.date.outputs.yearmonth }}
 
       - name: 変更をコミット＆プッシュ


### PR DESCRIPTION
## Summary

- `prompt` → `direct_prompt` に修正（無効なパラメータ名だった）
- `id-token: write` パーミッションを追加（OIDC トークン取得に必要）
- `mode: agent` を追加（`workflow_dispatch`/`schedule` イベントには agent モードが必要）

## 原因となったエラー

- https://github.com/kazrin/sk/actions/runs/26735134103 — `Unexpected input(s) 'prompt'` / `Could not fetch an OIDC token`
- https://github.com/kazrin/sk/actions/runs/26738164613 — `Tag mode cannot handle workflow_dispatch events`

🤖 Generated with [Claude Code](https://claude.com/claude-code)