### PR TITLE
ci: claude-code-action の設定を修正（allowed_tools 追加）

### DIFF
--- a/.github/workflows/monthly-data-update.yml
+++ b/.github/workflows/monthly-data-update.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           mode: agent
+          allowed_tools: "Edit,MultiEdit,Glob,Grep,LS,Read,Write,WebFetch,Bash"
           direct_prompt: /download-data ${{ steps.date.outputs.yearmonth }}
 
       - name: 変更をコミット＆プッシュ


### PR DESCRIPTION
## Summary

- `WebFetch` と `Bash` を `allowed_tools` に追加
  - `WebFetch`: 各地方厚生局からの Excel ダウンロードに必須
  - `Bash`: `uv run python` 実行に必須
- デフォルトで `DISALLOWED_TOOLS: WebSearch,WebFetch` になっていたため download-data スキルが動かなかった

## 原因となったエラー

https://github.com/kazrin/sk/actions/runs/26738344458/job/78796745685

```
DISALLOWED_TOOLS: WebSearch,WebFetch
Slash commands directory not found or error copying
is_error: true
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)