### PR TITLE
fix: claude-code-actionのモデルを明示指定して404エラーを解消

### DIFF
--- a/.github/workflows/monthly-data-update.yml
+++ b/.github/workflows/monthly-data-update.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           mode: agent
+          model: claude-sonnet-5
           allowed_tools: "Edit,MultiEdit,Glob,Grep,LS,Read,Write,WebFetch,Bash"
           direct_prompt: /download-data ${{ steps.date.outputs.yearmonth }}
 


### PR DESCRIPTION
## 概要
- `monthly-data-update.yml` の失敗原因を調査 ([該当実行](https://github.com/kazrin/sk/actions/runs/28493039641/job/84472855053))
- `claude-code-action@beta` がモデル未指定時にデフォルトで使う `claude-sonnet-4-20250514` が Anthropic 側で廃止され、API が `404 not_found_error` を返して毎回失敗していた
- `model: claude-sonnet-5` を明示指定して解消

## テスト計画
- [ ] `workflow_dispatch` で `monthly-data-update` を手動実行し、Claude ステップが成功することを確認