### PR TITLE
fix: 再実行時に同名ブランチのpush衝突が起きる問題を修正

### DIFF
--- a/.github/workflows/monthly-data-update.yml
+++ b/.github/workflows/monthly-data-update.yml
@@ -32,7 +32,9 @@ jobs:
           echo "branch=data/$(echo ${YM} | tr '/' '-')" >> $GITHUB_OUTPUT
 
       - name: データ更新ブランチを作成
-        run: git checkout -b ${{ steps.date.outputs.branch }}
+        run: |
+          git push origin --delete ${{ steps.date.outputs.branch }} 2>/dev/null || true
+          git checkout -b ${{ steps.date.outputs.branch }}
 
       - name: download-data スキルを実行
         uses: anthropics/claude-code-action@beta


### PR DESCRIPTION
## 概要
- [対象実行](https://github.com/kazrin/sk/actions/runs/28564399961/job/84688605113) にて `monthly-data-update` が失敗
- 原因: 前回失敗した実行が `data/2026-07` ブランチをリモートに作成済みのまま残っており、今回の実行が最新mainベースで同名ブランチを作り直して push した際に non-fast-forward で拒否された
- ブランチ作成前に同名のリモートブランチを削除（存在しなければ何もしない）してから作り直すよう修正

## 注意点
- 同月のワークフローを再実行するケースを想定した修正のため、同名ブランチに紐づく未マージPRがあった場合はブランチ削除時にそのPRがクローズされます（意図した再実行であれば問題ありません）

## テスト計画
- [ ] 一度 `workflow_dispatch` を実行してブランチ・PRを作った後、同じ年月で再実行し、ブランチ削除→再作成→pushが正常に通ることを確認