### PR TITLE
perf: uv未整備とcreate_feather.pyのタイムアウト再試行による無駄な待ち時間を削減

### DIFF
--- a/.claude/skills/download-data/SKILL.md
+++ b/.claude/skills/download-data/SKILL.md
@@ -46,13 +46,16 @@ find data/YYYY/MM/九州/ -name "*.xlsx" | grep -v '_ika' | xargs rm -f
 
 ## Step 4: feather生成
 
-ダウンロードしたxlsxファイルから `all.feather` を生成する:
+ダウンロードしたxlsxファイルから `all.feather` を生成する。42ファイル分の読み込みには10分前後かかることがあるため、**フォアグラウンドで実行しない**（Bashツールのタイムアウトで処理が強制終了され、最初からやり直しになる）。必ず最初からバックグラウンドで実行すること:
 
 ```bash
-uv run python create_feather.py \
+nohup uv run python create_feather.py \
   --input-dir-path data/YYYY/MM \
-  --output-file-path data/YYYY/MM/all.feather
+  --output-file-path data/YYYY/MM/all.feather \
+  > /tmp/create_feather.log 2>&1 &
 ```
+
+その後は`BashOutput`ツールや`sleep 60`程度の間隔でのポーリングで完了を待つ。**待っている間に同じコマンドを再実行しない**（プロセスが二重に走るだけで無駄になる）。`/tmp/create_feather.log` にエラーが出ていればユーザーに報告して停止する。
 
 エラーが出た場合はエラーメッセージをユーザーに報告して停止する。
 

--- a/.github/workflows/monthly-data-update.yml
+++ b/.github/workflows/monthly-data-update.yml
@@ -20,6 +20,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: uv をセットアップ
+        uses: astral-sh/setup-uv@v3
+
+      - name: 依存関係をインストール
+        run: uv sync
+
       - name: 年月とブランチ名を決定
         id: date
         run: |


### PR DESCRIPTION
## 概要
[対象実行](https://github.com/kazrin/sk/actions/runs/28564399961/job/84688605113) は成功したものの23分もかかっており、うち約17分が `all.feather` 生成に費やされていた。ログを追ったところ内訳は:

1. `uv: command not found`（CIに`uv`が未整備）→ pandas/openpyxlのpip代替インストールに約30秒
2. `python3 create_feather.py` をフォアグラウンド実行 → Bashツールの3分タイムアウトでkillされ、**最初からやり直し**
3. バックグラウンド実行に切り替えて再実行 → 完了まで約9〜13分（42ファイルのExcel読み込み自体の処理時間、ここは変更不可）

## 変更内容
- `.github/workflows/monthly-data-update.yml`: `astral-sh/setup-uv` と `uv sync` を追加し、`uv`が最初から使える状態にする（手探り復旧の約30秒＋やり直しの3分をカット）
- `.claude/skills/download-data/SKILL.md`: Step4を「最初からバックグラウンドで実行し、ポーリングで完了を待つ」に変更し、フォアグラウンドタイムアウトによる二重実行を防止

## 期待効果
- 想定短縮: 約3.5分（uv不在の手戻り分）
- Excel読み込み自体の9〜13分は変わらないため、劇的な短縮ではないが、今後同様の手戻りが起きなくなる

## テスト計画
- [ ] `workflow_dispatch` で手動実行し、`uv run python create_feather.py` が`uv: command not found`を出さずに成功することを確認
- [ ] Bashタイムアウトによる二重実行が発生しないことをログで確認